### PR TITLE
docs: update pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python library and tool for reading Committee on Earth Observation Satellites
 The project can be installed directly from the git repo. The CLI can be easily
 installed with [pipx](https://pypi.org/project/pipx/).
 ```
-pip install git+ssh://git@github.com:asfadmin/pyceos
+pip install git+ssh://git@github.com/asfadmin/pyceos
 ```
 
 When installing the CLI, the `jmespath` extra can be specified to enable


### PR DESCRIPTION
this is to address the error when running ``ssh: Could not resolve hostname github.com:asfadmin: nodename nor servname provided, or not known``