### PR TITLE
PR-3412 fix data set summary records parser

### DIFF
--- a/pyceos/records/data_set_summary_record/data_set_summary_record.py
+++ b/pyceos/records/data_set_summary_record/data_set_summary_record.py
@@ -7,8 +7,8 @@ from .sensor_specific import SensorSpecificAlos
 DataSetSummaryRecord = Struct(
     "sequence_number" / AsciiInt(4),
     "sar_chan" / AsciiInt(4),
-    "product_id" / AsciiString(16),
-    "scene_des" / AsciiString(32),
+    "product_id" / AsciiString(32),
+    "scene_des" / AsciiString(16),
     "inp_sctim" / AsciiString(32),
     "asc_des" / AsciiString(16),
     "pro_lat" / F16_7,


### PR DESCRIPTION
PER the ALOS document Data Set Summary Records should have field 9,10,11,12 as 32,16,32,16. 
Noticed when looking at a json dump of ALOS2 file ``0000424465_001001_ALOS2390800360-210818.zip``
That the body of the data_set_summary had a mismatch of what was expected.

Specifically related to my ouput when running both the cli and lib versions of the parser. This output was given in the data_set_summary which had a body which contained the following: 
```
        "product_id": "ALOS2390800360-2",
        "scene_des": "10818",
        "inp_sctim": "20210818050238953",
        "asc_des": "",
```
I believe it should be 
```
        "product_id": "ALOS2390800360-210818",
        "scene_des": "",
        "inp_sctim": "20210818050238953",
        "asc_des": "",
```
Based on fields 10 and 12 supposed to be blank by the [Alos-2 pdf](https://www.eorc.jaxa.jp/ALOS-2/en/doc/fdata/PALSAR-2_xx_Format_CEOS_E.pdf) Page 52

This change should correct this issue.