### PR TITLE
Lower Python requirement to 3.7>

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Rohan Weeden <reweeden@alaska.edu>"]
 pyceos = "pyceos.cli:main"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 construct = "^2.10.68"
 jmespath = { version = "^1.0", optional = true }
 


### PR DESCRIPTION
This is to address the requirement of lambda dependency layers are built in python 3.7.10